### PR TITLE
Keep widescreen through screen transitions

### DIFF
--- a/app/jni/src/snes/ppu.c
+++ b/app/jni/src/snes/ppu.c
@@ -50,6 +50,7 @@ void ppu_reset(Ppu* ppu) {
   ppu->extraLeftCur = 0;
   ppu->extraRightCur = 0;
   ppu->extraBottomCur = 0;
+  ppu->windowExtLeft = ppu->windowExtRight = NULL;
   ppu->vramPointer = 0;
   ppu->vramIncrementOnHigh = false;
   ppu->vramIncrement = 1;
@@ -217,16 +218,21 @@ static void PpuWindows_Calc(PpuWindows *win, Ppu *ppu, uint layer) {
   int window_right = 256 + (layer != 2 ? ppu->extraRightCur : 0);
   win->edges[0] = - (layer != 2 ? ppu->extraLeftCur : 0);
   win->edges[1] = window_right;
+  int w1_left = ppu->window1left, w1_right = ppu->window1right;
+  if (ppu->windowExtLeft) {
+    w1_left = IntMax(ppu->windowExtLeftCur, win->edges[0]);
+    w1_right = IntMin(ppu->windowExtRightCur, window_right - 1);
+  }
   uint i, j;
   int t;
-  bool w1_ena = (winflags & kWindow1Enabled) && ppu->window1left <= ppu->window1right;
+  bool w1_ena = (winflags & kWindow1Enabled) && w1_left <= w1_right;
   if (w1_ena) {
-    if (ppu->window1left > win->edges[0]) {
-      win->edges[nr] = ppu->window1left;
+    if (w1_left > win->edges[0]) {
+      win->edges[nr] = w1_left;
       win->edges[++nr] = window_right;
     }
-    if (ppu->window1right + 1 < window_right) {
-      win->edges[nr] = ppu->window1right + 1;
+    if (w1_right + 1 < window_right) {
+      win->edges[nr] = w1_right + 1;
       win->edges[++nr] = window_right;
     }
   }
@@ -253,8 +259,8 @@ static void PpuWindows_Calc(PpuWindows *win, Ppu *ppu, uint layer) {
   // get a bitmap of how regions map to windows
   uint8 w1_bits = 0, w2_bits = 0;
   if (w1_ena) {
-    for (i = 0; win->edges[i] != ppu->window1left; i++);
-    for (j = i; win->edges[j] != ppu->window1right + 1; j++);
+    for (i = 0; win->edges[i] != w1_left; i++);
+    for (j = i; win->edges[j] != w1_right + 1; j++);
     w1_bits = ((1 << (j - i)) - 1) << i;
   }
   if ((winflags & (kWindow1Enabled | kWindow1Inversed)) == (kWindow1Enabled | kWindow1Inversed))
@@ -698,6 +704,11 @@ void PpuSetExtraSideSpace(Ppu *ppu, int left, int right, int bottom) {
   ppu->extraBottomCur = UintMin(bottom, 16);
 }
 
+void PpuSetWindow1Ext(Ppu *ppu, const int16 *left, const int16 *right) {
+  ppu->windowExtLeft = left;
+  ppu->windowExtRight = right;
+}
+
 static FORCEINLINE float FloatInterpolate(float x, float xmin, float xmax, float ymin, float ymax) {
   return ymin + (ymax - ymin) * (x - xmin) * (1.0f / (xmax - xmin));
 }
@@ -845,6 +856,11 @@ static NOINLINE void PpuDrawWholeLine(Ppu *ppu, uint y) {
     size_t n = sizeof(uint32) * (256 + ppu->extraLeftRight * 2);
     memset(dst, 0, n);
     return;
+  }
+
+  if (ppu->windowExtLeft) {
+    ppu->windowExtLeftCur = ppu->windowExtLeft[y - 1];
+    ppu->windowExtRightCur = ppu->windowExtRight[y - 1];
   }
 
   if (ppu->mode == 7 && (ppu->renderFlags & kPpuRenderFlags_4x4Mode7)) {

--- a/app/jni/src/snes/ppu.h
+++ b/app/jni/src/snes/ppu.h
@@ -70,6 +70,8 @@ struct Ppu {
   uint8_t window2left;
   uint8_t window2right;
   uint32_t windowsel;
+  const int16_t *windowExtLeft, *windowExtRight;
+  int16_t windowExtLeftCur, windowExtRightCur;
 
   // color math
   uint8_t clipMode;
@@ -142,5 +144,6 @@ int PpuGetCurrentRenderScale(Ppu *ppu, uint32_t render_flags);
 
 void PpuSetMode7PerspectiveCorrection(Ppu *ppu, int low, int high);
 void PpuSetExtraSideSpace(Ppu *ppu, int left, int right, int bottom);
+void PpuSetWindow1Ext(Ppu *ppu, const int16_t *left, const int16_t *right);
 
 #endif  // ZELDA3_SNES_PPU_H_

--- a/app/jni/src/src/load_gfx.c
+++ b/app/jni/src/src/load_gfx.c
@@ -307,6 +307,10 @@ static const int8 kOwSprPalInfo[40] = {
 };
 static const int8 kSpotlight_delta_size[4] = {-7, 7, 7, 7};
 static const uint8 kSpotlight_goal[4] = {0, 126, 35, 126};
+int16 g_spotlight_ext_left[240];
+int16 g_spotlight_ext_right[240];
+bool g_spotlight_ext_active;
+static int16 spotlight_ext_x0, spotlight_ext_x1;
 static const uint8 kConfigureSpotlightTable_Helper_Tab[129] = {
   0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe, 0xfe, 0xfe, 0xfe, 0xfd, 0xfd, 0xfd, 0xfd, 0xfc, 0xfc, 0xfc, 0xfb, 0xfb, 0xfb, 0xfa, 0xfa, 0xf9, 0xf9, 0xf8, 0xf8,
   0xf7, 0xf7, 0xf6, 0xf6, 0xf5, 0xf5, 0xf4, 0xf3, 0xf3, 0xf2, 0xf1, 0xf1, 0xf0, 0xef, 0xee, 0xee, 0xed, 0xec, 0xeb, 0xea, 0xe9, 0xe9, 0xe8, 0xe7, 0xe6, 0xe5, 0xe4, 0xe3, 0xe2, 0xe1, 0xdf, 0xde,
@@ -1421,7 +1425,7 @@ void Trinexx_UnflashShellPalette_Blue() {  // 80f253
 }
 
 void IrisSpotlight_close() {  // 80f28b
-  SpotlightInternal(0x7e, 0);
+  SpotlightInternal((enhanced_features0 & kFeatures0_WidescreenVisualFixes) ? 144 : 0x7e, 0);
 }
 
 void Spotlight_open() {  // 80f295
@@ -1462,30 +1466,49 @@ void IrisSpotlight_ConfigureTable() {  // 80f312
   uint16 r4 = r14 * 2 - r6;
   for(;;) {
     uint16 r8 = 0xff;
+    spotlight_ext_x0 = 255, spotlight_ext_x1 = 0;
     if (r6 < spotlight_y_upper) {
       uint8 t = spotlight_var4;
       if (spotlight_var4)
         spotlight_var4--;
       r8 = IrisSpotlight_CalculateCircleValue(t);
     }
-    if (r4 < 240)
+    if (r4 < 240) {
       hdma_table_dynamic[r4] = r8;
-    if (r6 < 240)
+      g_spotlight_ext_left[r4] = spotlight_ext_x0, g_spotlight_ext_right[r4] = spotlight_ext_x1;
+    }
+    if (r6 < 240) {
       hdma_table_dynamic[r6] = r8;
+      g_spotlight_ext_left[r6] = spotlight_ext_x0, g_spotlight_ext_right[r6] = spotlight_ext_x1;
+    }
     if (r4 == r14)
       break;
     r4++, r6--;
   }
 
-  for (int i = 224; i < 240; i++)
+  for (int i = 224; i < 240; i++) {
     hdma_table_dynamic[i] = 0;
+    g_spotlight_ext_left[i] = 0, g_spotlight_ext_right[i] = 0;
+  }
 
   memcpy(hdma_table_unused, hdma_table_dynamic, 224  * sizeof(uint16));
 
-  spotlight_var1 += kSpotlight_delta_size[spotlight_var2 >> 1];
-
-  if (spotlight_var1 != kSpotlight_goal[spotlight_var2 >> 1])
-    return;
+  int delta = kSpotlight_delta_size[spotlight_var2 >> 1];
+  int goal = kSpotlight_goal[spotlight_var2 >> 1];
+  if (enhanced_features0 & kFeatures0_WidescreenVisualFixes) {
+    g_spotlight_ext_active = true;
+    delta = delta < 0 ? -8 : 8;
+    if (goal == 126)
+      goal = 144;
+    spotlight_var1 += delta;
+    if (delta < 0 ? (int16)spotlight_var1 > 0 : (int16)spotlight_var1 < goal)
+      return;
+    spotlight_var1 = goal;
+  } else {
+    spotlight_var1 += delta;
+    if (spotlight_var1 != goal)
+      return;
+  }
 
   if (!spotlight_var2) {
     INIDISP_copy = 0x80;
@@ -1507,8 +1530,10 @@ void IrisSpotlight_ConfigureTable() {  // 80f312
 }
 
 void IrisSpotlight_ResetTable() {  // 80f427
-  for (int i = 0; i < 240; i++)
+  for (int i = 0; i < 240; i++) {
     hdma_table_dynamic[i] = 0xff00;
+    g_spotlight_ext_left[i] = -kPpuExtraLeftRight, g_spotlight_ext_right[i] = 255 + kPpuExtraLeftRight;
+  }
 }
 
 uint16 IrisSpotlight_CalculateCircleValue(uint8 a) {  // 80f4cc
@@ -1523,7 +1548,10 @@ uint16 IrisSpotlight_CalculateCircleValue(uint8 a) {  // 80f4cc
          r0 < 255 ? r0 : 255;
   r2 = r2 < 255 ? r2 : 255;
   r0 |= r2 << 8;
-  return r0 == 0xffff ? 0xff : r0;
+  if (r0 == 0xffff)
+    return 0xff;
+  spotlight_ext_x0 = spotlight_var3 - p, spotlight_ext_x1 = spotlight_var3 + p;
+  return r0;
 }
 
 void AdjustWaterHDMAWindow() {  // 80f649

--- a/app/jni/src/src/load_gfx.h
+++ b/app/jni/src/src/load_gfx.h
@@ -12,6 +12,9 @@ enum {
 };
 
 extern uint16 kGlovesColor[2];
+extern int16 g_spotlight_ext_left[240];
+extern int16 g_spotlight_ext_right[240];
+extern bool g_spotlight_ext_active;
 
 void ApplyPaletteFilter_bounce();
 void PaletteFilter_Range(int from, int to);

--- a/app/jni/src/src/zelda_rtl.c
+++ b/app/jni/src/src/zelda_rtl.c
@@ -1,6 +1,7 @@
 #include "zelda_rtl.h"
 #include "variables.h"
 #include "misc.h"
+#include "load_gfx.h"
 #include "nmi.h"
 #include "poly.h"
 #include "attract.h"
@@ -150,6 +151,10 @@ static void ConfigurePpuSideSpace() {
   int mod = main_module_index;
   if (mod == 14)
     mod = saved_module_for_menu;
+  if ((enhanced_features0 & kFeatures0_WidescreenVisualFixes) &&
+      (mod == 6 || mod == 8 || mod == 10 || mod == 15 || mod == 16 || mod == 17 ||
+       mod == 18 || mod == 19 || mod == 21 || mod == 22 || mod == 23))
+    mod = player_is_indoors ? 7 : 9;
   if (mod == 9) {
     if (main_module_index == 14 && submodule_index == 7 && overworld_map_state >= 4) {
       // World map
@@ -202,6 +207,9 @@ void ZeldaDrawPpuFrame(uint8 *pixel_buffer, size_t pitch, uint32 render_flags) {
 
   if (g_zenv.ppu->extraLeftRight != 0 || render_flags & kPpuRenderFlags_Height240)
     ConfigurePpuSideSpace();
+
+  PpuSetWindow1Ext(g_zenv.ppu, g_spotlight_ext_active ? g_spotlight_ext_left : NULL,
+                   g_spotlight_ext_active ? g_spotlight_ext_right : NULL);
 
   int height = render_flags & kPpuRenderFlags_Height240 ? 240 : 224;
 
@@ -262,6 +270,7 @@ static void ClearOamBuffer() {  // 80841e
 
 static void ZeldaRunGameLoop() {
   frame_counter++;
+  g_spotlight_ext_active = false;
   ClearOamBuffer();
   Module_MainRouting();
   NMI_PrepareSprites();


### PR DESCRIPTION
With ExtendedAspectRatio set to 16:9 the picture snapped back to 4:3 for the duration of every screen transition and then popped back out again, so you got a black bar on each side whenever you walked through a door, fell in a hole, warped or died.

Two things caused it:

* `ConfigurePpuSideSpace` only handed out the extra side pixels for the overworld, dungeon, menu and title modules. Every other module got zero, and door/spotlight transitions run modules 0x06, 0x08, 0x0F, 0x10 and friends.
* The spotlight iris is an HDMA window effect. Its per-scanline left and right edges are packed into one byte each, so the circle physically cannot reach past x=255 and the wipe could never cover a wider screen.

The transition modules are now mapped back to the overworld or dungeon case depending on `player_is_indoors`, so they keep the side space of the world that is actually on screen and still clamp to the live scroll bounds. The load modules run under forced blank, which is drawn across the full width, so no stale tilemap can show up in the margins.

For the iris, the vanilla packed table is left alone and a parallel pair of int16 per-scanline tables carries the unclamped circle edges. The ppu latches those per line and clamps them to the current screen bounds, which reproduces the original values exactly whenever there is no side space, so 4:3 and dark lantern rooms are untouched. The circle also starts a little bigger (radius 144 instead of 126, step 8 instead of 7) so the wipe still takes the same 18 frames but reaches the edges of a widescreen picture.

All of it sits behind the existing widescreen visual fixes flag, so `no_visual_fixes` in zelda3.ini restores the old behaviour.

Tested in the emulator: entering and leaving houses and caves, and normal overworld and dungeon play afterwards.