### PR TITLE
Correct second screen from being dismissed separately of main

### DIFF
--- a/app/src/main/java/com/dishii/zelda3/MainActivity.java
+++ b/app/src/main/java/com/dishii/zelda3/MainActivity.java
@@ -125,7 +125,7 @@ public class MainActivity extends SDLActivity {
     public void setOrientationBis(int w, int h, boolean resizable, String hint) {
         setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
     }
-    
+
     // Show the companion Presentation on the first non-default display
     // (the Ayn Thor's bottom screen, or an emulator's simulated display).
     private void showSecondScreenIfPresent() {

--- a/app/src/main/java/com/dishii/zelda3/MainActivity.java
+++ b/app/src/main/java/com/dishii/zelda3/MainActivity.java
@@ -125,7 +125,7 @@ public class MainActivity extends SDLActivity {
     public void setOrientationBis(int w, int h, boolean resizable, String hint) {
         setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
     }
-
+    
     // Show the companion Presentation on the first non-default display
     // (the Ayn Thor's bottom screen, or an emulator's simulated display).
     private void showSecondScreenIfPresent() {
@@ -148,6 +148,19 @@ public class MainActivity extends SDLActivity {
             }
             return;
         }
+    }
+
+    /** Dismiss and resume second screen based off main instance state */
+    @Override
+    protected void onPause() {
+        super.onPause();
+        dismissSecondScreen();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        showSecondScreenIfPresent();
     }
 
     private void dismissSecondScreen() {

--- a/app/src/main/java/com/dishii/zelda3/SecondScreenPresentation.java
+++ b/app/src/main/java/com/dishii/zelda3/SecondScreenPresentation.java
@@ -44,6 +44,11 @@ public class SecondScreenPresentation extends Presentation {
         setContentView(minimap);
     }
 
+    /** Prevent dismissing the second screen with Back button and gesture. */
+    @Override
+    public void onBackPressed() {
+    }
+
     /** Debug: render the current view into a PNG (triggered via adb broadcast). */
     public void dumpToFile(File file) {
         if (minimap == null || minimap.getWidth() == 0) return;


### PR DESCRIPTION
Proposed fix for #2: Lined up behaviour of second screen with the main screen to prevent it from being dismissed by itself and to follow the state of the main screen.