### PR TITLE
Add a Map button to the bottom screen tab bar

### DIFF
--- a/app/jni/src/src/platform/linux/second_screen_sdl.c
+++ b/app/jni/src/src/platform/linux/second_screen_sdl.c
@@ -156,7 +156,7 @@ static void rebuild_renderer(int w2, int h2);
 static bool ss_needs_rebuild;
 
 // touch rects recomputed every draw, used by the tap handler
-static RectFS map_area_r, tab_items_r, tab_gear_r, tab_settings_r, y_ring_r;
+static RectFS map_area_r, tab_items_r, tab_gear_r, tab_map_r, tab_settings_r, y_ring_r;
 static RectFS settings_row_r[3], remap_row_r[12], remap_back_r;
 
 // settings / remap state
@@ -939,10 +939,14 @@ static void draw_tab_bar(float tab_h) {
   float bh = tab_h - 16 * u;
   float sq = bh;   // square settings button on the right
   tab_settings_r = (RectFS){W - 8 * u - sq, y, sq, bh};
-  float half = (W - sq - 10 * u) / 2.0f;
-  tab_gear_r  = (RectFS){8 * u, y, half - 13 * u, bh};
-  tab_items_r = (RectFS){half + 5 * u, y, W - 18 * u - sq - (half + 5 * u), bh};
+  // three equal buttons: GEAR | MAP | ITEMS, left of the settings cog
+  float x0 = 8 * u, xr = tab_settings_r.x - 8 * u, tgap = 8 * u;
+  float bw = (xr - x0 - 2 * tgap) / 3.0f;
+  tab_gear_r  = (RectFS){x0, y, bw, bh};
+  tab_map_r   = (RectFS){x0 + bw + tgap, y, bw, bh};
+  tab_items_r = (RectFS){x0 + 2 * (bw + tgap), y, bw, bh};
   draw_tab_button(tab_gear_r, "GEAR", tab == TAB_GEAR);
+  draw_tab_button(tab_map_r, "MAP", tab == TAB_MAP);
   draw_tab_button(tab_items_r, "ITEMS", tab == TAB_ITEMS);
   draw_tab_button(tab_settings_r, NULL, tab == TAB_SETTINGS);
   draw_cog(tab_settings_r.x + tab_settings_r.w / 2, tab_settings_r.y + tab_settings_r.h / 2,
@@ -1014,6 +1018,7 @@ static void handle_tap(float x, float y) {
   if (mode_for_module(module) != MODE_GAME || !art_ready) return;
 
   if (in_rect(&tab_items_r, x, y)) { tab = (tab == TAB_ITEMS) ? TAB_MAP : TAB_ITEMS; leave_remap(); return; }
+  if (in_rect(&tab_map_r, x, y))   { tab = TAB_MAP; leave_remap(); return; }
   if (in_rect(&tab_gear_r, x, y))  { tab = (tab == TAB_GEAR) ? TAB_MAP : TAB_GEAR; leave_remap(); return; }
   if (in_rect(&tab_settings_r, x, y)) { tab = (tab == TAB_SETTINGS) ? TAB_MAP : TAB_SETTINGS; leave_remap(); return; }
 

--- a/app/src/main/java/com/dishii/zelda3/MinimapView.java
+++ b/app/src/main/java/com/dishii/zelda3/MinimapView.java
@@ -127,7 +127,7 @@ public class MinimapView extends View {
     };
 
     // touch regions (recomputed during draw)
-    private final RectF tabItemsR = new RectF(), tabGearR = new RectF();
+    private final RectF tabItemsR = new RectF(), tabGearR = new RectF(), tabMapR = new RectF();
     private final RectF tabSettingsR = new RectF(), remapBackR = new RectF();
     private final RectF[] settingsRowR = new RectF[4 + FEAT_MASKS.length];
     private final RectF[] remapRowR = new RectF[12];
@@ -1068,10 +1068,13 @@ public class MinimapView extends View {
         float bh = tabH - 34 * u;   // keep clear of the bottom gesture inset
         float sq = bh;              // square settings button on the right
         tabSettingsR.set(w - 8 * u - sq, y, w - 8 * u, y + bh);
-        float half = (w - sq - 10 * u) / 2f;
-        tabGearR.set(8 * u, y, half - 5 * u, y + bh);
-        tabItemsR.set(half + 5 * u, y, w - 18 * u - sq, y + bh);
+        float x0 = 8 * u, xr = tabSettingsR.left - 8 * u, tgap = 8 * u;
+        float bw = (xr - x0 - 2 * tgap) / 3f;
+        tabGearR.set(x0, y, x0 + bw, y + bh);
+        tabMapR.set(x0 + bw + tgap, y, x0 + 2 * bw + tgap, y + bh);
+        tabItemsR.set(x0 + 2 * (bw + tgap), y, x0 + 3 * bw + 2 * tgap, y + bh);
         drawTabButton(c, tabGearR, "GEAR", tab == TAB_GEAR);
+        drawTabButton(c, tabMapR, "MAP", tab == TAB_MAP);
         drawTabButton(c, tabItemsR, "ITEMS", tab == TAB_ITEMS);
         drawTabButton(c, tabSettingsR, null, tab == TAB_SETTINGS);
         drawCog(c, tabSettingsR.centerX(), tabSettingsR.centerY(), bh * 0.28f);
@@ -1395,6 +1398,7 @@ public class MinimapView extends View {
         if (action != MotionEvent.ACTION_DOWN) return true;
 
         if (tabItemsR.contains(x, y)) { tab = (tab == TAB_ITEMS) ? TAB_MAP : TAB_ITEMS; leaveRemap(); return true; }
+        if (tabMapR.contains(x, y)) { tab = TAB_MAP; leaveRemap(); return true; }
         if (tabGearR.contains(x, y)) { tab = (tab == TAB_GEAR) ? TAB_MAP : TAB_GEAR; leaveRemap(); return true; }
         if (tabSettingsR.contains(x, y)) {
             tab = (tab == TAB_SETTINGS) ? TAB_MAP : TAB_SETTINGS;


### PR DESCRIPTION
Splits the GEAR|ITEMS tab bar into three equal GEAR|MAP|ITEMS buttons so the map is reachable directly instead of only by toggling another tab off.

This needs a test with android.