### PR TITLE
Add top screen decoration in 4:3

### DIFF
--- a/app/jni/src/src/opengl.c
+++ b/app/jni/src/src/opengl.c
@@ -9,6 +9,11 @@
 
 #define CODE(...) #__VA_ARGS__
 
+// Location-themed, framed letterbox chrome for the main window. The Linux
+// build draws it (see second_screen_sdl.c); Android returns NULL so the bars
+// stay black.
+extern const uint32_t *LetterboxBackground(int dw, int dh, int vx, int vy, int vw, int vh);
+
 static SDL_Window *g_window;
 static SDL_GLContext g_context;
 static uint8 *g_screen_buffer;
@@ -18,6 +23,7 @@ static unsigned int g_program, g_VAO;
 static GlTextureWithSize g_texture;
 static GlslShader *g_glsl_shader;
 static bool g_opengl_es;
+static unsigned int g_border_tex;
 
 static void GL_APIENTRY MessageCallback(GLenum source,
                 GLenum type,
@@ -198,6 +204,34 @@ static void OpenGLRenderer_BeginDraw(int width, int height, uint8 **pixels, int 
   *pitch = width * 4;
 }
 
+// Fill the letterbox bars with the location-themed, framed background the
+// Linux frontend produces (opengl.c stays art-agnostic). LetterboxBackground
+// hands back a drawable-sized ARGB image to upload, or NULL when nothing has
+// changed since the last call (keep the texture) or on Android (no chrome).
+static void DrawLetterboxPattern(int dw, int dh, int vx, int vy, int vw, int vh) {
+  const uint32_t *bg = LetterboxBackground(dw, dh, vx, vy, vw, vh);
+  if (bg) {
+    if (!g_border_tex)
+      glGenTextures(1, &g_border_tex);
+    glBindTexture(GL_TEXTURE_2D, g_border_tex);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    if (!g_opengl_es)
+      glTexImage2D(GL_TEXTURE_2D, 0, GL_BGRA, dw, dh, 0, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, bg);
+    else
+      glTexImage2D(GL_TEXTURE_2D, 0, GL_BGRA, dw, dh, 0, GL_BGRA, GL_UNSIGNED_BYTE, bg);
+  }
+  if (!g_border_tex)
+    return;  // Android / nothing uploaded -> bars stay black
+  glViewport(0, 0, dw, dh);
+  glUseProgram(g_program);
+  glBindTexture(GL_TEXTURE_2D, g_border_tex);
+  glBindVertexArray(g_VAO);
+  glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+}
+
 static void OpenGLRenderer_EndDraw() {
   int drawable_width, drawable_height;
 
@@ -234,9 +268,14 @@ static void OpenGLRenderer_EndDraw() {
   glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
   glClear(GL_COLOR_BUFFER_BIT);
 
+  if (viewport_width < drawable_width || viewport_height < drawable_height)
+    DrawLetterboxPattern(drawable_width, drawable_height,
+                         viewport_x, viewport_y, viewport_width, viewport_height);
+
   if (g_glsl_shader == NULL) {
     glViewport(viewport_x, viewport_y, viewport_width, viewport_height);
     glUseProgram(g_program);
+    glBindTexture(GL_TEXTURE_2D, g_texture.gl_texture);
     int filter = g_config.linear_filtering ? GL_LINEAR : GL_NEAREST;
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter);

--- a/app/jni/src/src/platform/android/second_screen_sdl_stub.c
+++ b/app/jni/src/src/platform/android/second_screen_sdl_stub.c
@@ -3,13 +3,84 @@
 #include <SDL.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdlib.h>
+#include "../linux/ss_textures.h"   // baked theme background tiles (menu/stone)
 
 bool SecondScreenSDL_Init(SDL_Window *main_window) { (void)main_window; return false; }
 bool SecondScreenSDL_HandleEvent(const SDL_Event *e) { (void)e; return false; }
 void SecondScreenSDL_Update(void) {}
 void SecondScreenSDL_Shutdown(void) {}
 
-// The Android letterbox stays black; the Presentation UI owns the bottom panel.
+// --- Main-window letterbox chrome ----
+
+// SS_* core - indoor/dungeon state drives the theme.
+bool SS_IsIndoors(void);
+int  SS_GetDungeon(void);
+
+// palette
+#define COL(r,g,b) (0xff000000u | ((r) << 16) | ((g) << 8) | (b))
+enum {
+  COL_GOLD      = COL(232, 194, 96),
+  COL_GOLD_DARK = COL(122, 88, 30),
+  COL_BOX       = COL(12, 12, 12),
+};
+#undef COL
+
+static uint32_t *g_lb_buf;
+static int g_lb_dw, g_lb_dh, g_lb_vx, g_lb_vy, g_lb_vw, g_lb_vh, g_lb_theme = -1;
+
+static void lb_fill(uint32_t *buf, int dw, int dh, int x, int y, int w, int h, uint32_t c) {
+  if (x < 0) { w += x; x = 0; }
+  if (y < 0) { h += y; y = 0; }
+  if (x + w > dw) w = dw - x;
+  if (y + h > dh) h = dh - y;
+  for (int yy = 0; yy < h; yy++) {
+    uint32_t *row = &buf[(size_t)(y + yy) * dw + x];
+    for (int xx = 0; xx < w; xx++) row[xx] = c;
+  }
+}
+
+// One frame band of thickness t hugging the outside of (rx,ry,rw,rh); grows it.
+static void lb_ring(uint32_t *buf, int dw, int dh, int *rx, int *ry, int *rw, int *rh, int t, uint32_t c) {
+  lb_fill(buf, dw, dh, *rx - t, *ry - t, *rw + 2 * t, t, c);   // top
+  lb_fill(buf, dw, dh, *rx - t, *ry + *rh, *rw + 2 * t, t, c); // bottom
+  lb_fill(buf, dw, dh, *rx - t, *ry, t, *rh, c);              // left
+  lb_fill(buf, dw, dh, *rx + *rw, *ry, t, *rh, c);            // right
+  *rx -= t; *ry -= t; *rw += 2 * t; *rh += 2 * t;
+}
+
 const uint32_t *LetterboxBackground(int dw, int dh, int vx, int vy, int vw, int vh) {
-  (void)dw; (void)dh; (void)vx; (void)vy; (void)vw; (void)vh; return NULL;
+  bool indoors = SS_IsIndoors();
+  int dungeon_info = SS_GetDungeon();
+  bool in_house = indoors && (dungeon_info & 0xFF) == 0xFF;
+  int theme = (indoors && !in_house) ? 1 : 0;  // 1 = dungeon stone, 0 = menu cloth
+
+  if (g_lb_buf && dw == g_lb_dw && dh == g_lb_dh && vx == g_lb_vx && vy == g_lb_vy &&
+      vw == g_lb_vw && vh == g_lb_vh && theme == g_lb_theme)
+    return NULL;  // unchanged: the renderer reuses its texture
+
+  if (!g_lb_buf || dw != g_lb_dw || dh != g_lb_dh) {
+    free(g_lb_buf);
+    g_lb_buf = malloc((size_t)dw * dh * 4);
+    if (!g_lb_buf) return NULL;
+  }
+  g_lb_dw = dw, g_lb_dh = dh, g_lb_vx = vx, g_lb_vy = vy, g_lb_vw = vw, g_lb_vh = vh, g_lb_theme = theme;
+
+  const uint32_t *tile = theme ? (const uint32_t *)kSSTexStone : (const uint32_t *)kSSTexMenu;
+  int tw = theme ? kSSTexStone_W : kSSTexMenu_W;
+  int th = theme ? kSSTexStone_H : kSSTexMenu_H;
+  int zoom = dh / 360; if (zoom < 2) zoom = 2;
+  for (int y = 0; y < dh; y++) {
+    const uint32_t *srow = &tile[(y / zoom % th) * tw];
+    uint32_t *drow = &g_lb_buf[(size_t)y * dw];
+    for (int x = 0; x < dw; x++) drow[x] = srow[x / zoom % tw];
+  }
+
+  // Frame the play area with the map panel's gold double border.
+  int u = dh / 240; if (u < 1) u = 1;
+  int rx = vx, ry = vy, rw = vw, rh = vh;
+  lb_ring(g_lb_buf, dw, dh, &rx, &ry, &rw, &rh, 1 * u, COL_BOX);        // shadow gap
+  lb_ring(g_lb_buf, dw, dh, &rx, &ry, &rw, &rh, 2 * u, COL_GOLD);       // inner gold
+  lb_ring(g_lb_buf, dw, dh, &rx, &ry, &rw, &rh, 2 * u, COL_GOLD_DARK);  // outer dark gold
+  return g_lb_buf;
 }

--- a/app/jni/src/src/platform/android/second_screen_sdl_stub.c
+++ b/app/jni/src/src/platform/android/second_screen_sdl_stub.c
@@ -2,8 +2,14 @@
 // Java Presentation UI). Keeps main.c link-clean without compiling the SDL UI.
 #include <SDL.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 bool SecondScreenSDL_Init(SDL_Window *main_window) { (void)main_window; return false; }
 bool SecondScreenSDL_HandleEvent(const SDL_Event *e) { (void)e; return false; }
 void SecondScreenSDL_Update(void) {}
 void SecondScreenSDL_Shutdown(void) {}
+
+// The Android letterbox stays black; the Presentation UI owns the bottom panel.
+const uint32_t *LetterboxBackground(int dw, int dh, int vx, int vy, int vw, int vh) {
+  (void)dw; (void)dh; (void)vx; (void)vy; (void)vw; (void)vh; return NULL;
+}

--- a/app/jni/src/src/platform/linux/second_screen_sdl.c
+++ b/app/jni/src/src/platform/linux/second_screen_sdl.c
@@ -333,6 +333,72 @@ static SDL_Texture *make_tex(int w, int h, const uint32_t *px, bool blend) {
   return t;
 }
 
+// --- Main-window letterbox chrome -------------------------------------------
+// Exposed to the GL renderer (opengl.c). When the maintained aspect leaves
+// pillarbox/letterbox bars, fill them with the same location theme the bottom
+// screen uses (green menu cloth outdoors, dungeon stone indoors) and frame the
+// play area with the map panel's gold border. Returns a drawable-sized ARGB
+// image to upload, or NULL when nothing changed since the last call (the
+// renderer keeps its texture) - so real work only happens on a theme/size flip.
+static uint32_t *g_lb_buf;
+static int g_lb_dw, g_lb_dh, g_lb_vx, g_lb_vy, g_lb_vw, g_lb_vh, g_lb_theme = -1;
+
+static void lb_fill(uint32_t *buf, int dw, int dh, int x, int y, int w, int h, uint32_t c) {
+  if (x < 0) { w += x; x = 0; }
+  if (y < 0) { h += y; y = 0; }
+  if (x + w > dw) w = dw - x;
+  if (y + h > dh) h = dh - y;
+  for (int yy = 0; yy < h; yy++) {
+    uint32_t *row = &buf[(size_t)(y + yy) * dw + x];
+    for (int xx = 0; xx < w; xx++) row[xx] = c;
+  }
+}
+
+// One frame band of thickness t hugging the outside of (rx,ry,rw,rh); grows it.
+static void lb_ring(uint32_t *buf, int dw, int dh, int *rx, int *ry, int *rw, int *rh, int t, uint32_t c) {
+  lb_fill(buf, dw, dh, *rx - t, *ry - t, *rw + 2 * t, t, c);   // top
+  lb_fill(buf, dw, dh, *rx - t, *ry + *rh, *rw + 2 * t, t, c); // bottom
+  lb_fill(buf, dw, dh, *rx - t, *ry, t, *rh, c);              // left
+  lb_fill(buf, dw, dh, *rx + *rw, *ry, t, *rh, c);            // right
+  *rx -= t; *ry -= t; *rw += 2 * t; *rh += 2 * t;
+}
+
+const uint32_t *LetterboxBackground(int dw, int dh, int vx, int vy, int vw, int vh) {
+  bool indoors = SS_IsIndoors();
+  int dungeon_info = SS_GetDungeon();
+  bool in_house = indoors && (dungeon_info & 0xFF) == 0xFF;
+  int theme = (indoors && !in_house) ? 1 : 0;  // 1 = dungeon stone, 0 = menu cloth
+
+  if (g_lb_buf && dw == g_lb_dw && dh == g_lb_dh && vx == g_lb_vx && vy == g_lb_vy &&
+      vw == g_lb_vw && vh == g_lb_vh && theme == g_lb_theme)
+    return NULL;  // unchanged: the renderer reuses its texture
+
+  if (!g_lb_buf || dw != g_lb_dw || dh != g_lb_dh) {
+    free(g_lb_buf);
+    g_lb_buf = malloc((size_t)dw * dh * 4);
+    if (!g_lb_buf) return NULL;
+  }
+  g_lb_dw = dw, g_lb_dh = dh, g_lb_vx = vx, g_lb_vy = vy, g_lb_vw = vw, g_lb_vh = vh, g_lb_theme = theme;
+
+  const uint32_t *tile = theme ? (const uint32_t *)kSSTexStone : (const uint32_t *)kSSTexMenu;
+  int tw = theme ? kSSTexStone_W : kSSTexMenu_W;
+  int th = theme ? kSSTexStone_H : kSSTexMenu_H;
+  int zoom = dh / 360; if (zoom < 2) zoom = 2;
+  for (int y = 0; y < dh; y++) {
+    const uint32_t *srow = &tile[(y / zoom % th) * tw];
+    uint32_t *drow = &g_lb_buf[(size_t)y * dw];
+    for (int x = 0; x < dw; x++) drow[x] = srow[x / zoom % tw];
+  }
+
+  // Frame the play area with the map panel's gold double border.
+  int u = dh / 240; if (u < 1) u = 1;
+  int rx = vx, ry = vy, rw = vw, rh = vh;
+  lb_ring(g_lb_buf, dw, dh, &rx, &ry, &rw, &rh, 1 * u, COL_BOX);        // shadow gap
+  lb_ring(g_lb_buf, dw, dh, &rx, &ry, &rw, &rh, 2 * u, COL_GOLD);       // inner gold
+  lb_ring(g_lb_buf, dw, dh, &rx, &ry, &rw, &rh, 2 * u, COL_GOLD_DARK);  // outer dark gold
+  return g_lb_buf;
+}
+
 // Tile a theme texture across r at 2x, clipped
 static void draw_tiled(SDL_Texture *tex, int tw, int th, RectFS r, uint32_t fallback) {
   if (!tex) { fill_rect(r.x, r.y, r.w, r.h, fallback); return; }

--- a/app/src/main/assets/zelda3.ini
+++ b/app/src/main/assets/zelda3.ini
@@ -54,7 +54,7 @@ NoSpriteLimits = 1
 
 # Use either SDL, SDL-Software, OpenGL, or OpenGL ES as the output method
 # SDL-Software rendering might give better performance on Raspberry pi.
-OutputMethod = SDL
+OutputMethod = OpenGL ES
 
 # Set to true to use linear filtering. Gives less crisp pixels. Works with SDL and OpenGL.
 LinearFiltering = 0


### PR DESCRIPTION
This adds top screen decoration when using 4:3 mode instead of having black pillarboxes. Theme matches the bottom screen. Needs an android test, and does not work in SDL so default renderer was changed to OpenGL ES.