### PR TITLE
Fix bottom screen stuck on cinema card in dungeonless rooms (#9)

### DIFF
--- a/app/jni/src/src/platform/android/second_screen_jni.c
+++ b/app/jni/src/src/platform/android/second_screen_jni.c
@@ -16,6 +16,7 @@ void SS_SetHudHidden(bool hide); bool SS_IsHudHidden(void); void SS_ArmButtonCap
 int SS_GetCapturedButton(void); void SS_GetGamepadControls(int *out); void SS_SetGamepadControls(const int *in);
 int SS_GetEquippedSlotX(void); void SS_AssignSlotX(int slot);
 uint32 SS_GetFeatures(void); void SS_SetFeature(unsigned mask, bool on);
+bool SS_GetIndoorExit(int *out);
 
 #include <jni.h>
 
@@ -29,6 +30,14 @@ JNIEXPORT jboolean JNICALL Java_com_dishii_zelda3_GameState_isIndoors(JNIEnv *en
 JNIEXPORT jint JNICALL Java_com_dishii_zelda3_GameState_getEquippedSlot(JNIEnv *env, jclass clazz) { return SS_GetEquippedSlot(); }
 JNIEXPORT jint JNICALL Java_com_dishii_zelda3_GameState_getEquippedSlotX(JNIEnv *env, jclass clazz) { return SS_GetEquippedSlotX(); }
 JNIEXPORT jint JNICALL Java_com_dishii_zelda3_GameState_getDungeon(JNIEnv *env, jclass clazz) { return SS_GetDungeon(); }
+
+JNIEXPORT jboolean JNICALL Java_com_dishii_zelda3_GameState_getIndoorExit(JNIEnv *env, jclass clazz, jintArray out) {
+  if ((*env)->GetArrayLength(env, out) < 3) return false;
+  int tmp[3];
+  if (!SS_GetIndoorExit(tmp)) return false;
+  (*env)->SetIntArrayRegion(env, out, 0, 3, (const jint *)tmp);
+  return true;
+}
 
 JNIEXPORT void JNICALL Java_com_dishii_zelda3_GameState_readSram(JNIEnv *env, jclass clazz, jbyteArray out) {
   uint8 tmp[0x100];

--- a/app/jni/src/src/platform/linux/second_screen_sdl.c
+++ b/app/jni/src/src/platform/linux/second_screen_sdl.c
@@ -31,6 +31,7 @@ bool SS_IsIndoors(void);
 void SS_ReadSram(uint8_t *out, int n);
 int  SS_GetEquippedSlot(void);
 int  SS_GetDungeon(void);
+bool SS_GetIndoorExit(int *out);
 void SS_ReadDungFlags(uint8_t *out, int n);
 bool SS_RenderIconSheet(uint32_t *px);
 bool SS_RenderGlyphSheet(uint32_t *px);
@@ -1161,9 +1162,14 @@ void SecondScreenSDL_Update(void) {
   bool dungeon_mode = indoors;
   int ui_mode = mode_for_module(module);
   if (module == 0x12 || module <= 0x05) has_last_outdoor = false;
-  // houses/caves have no dungeon map: keep the overworld view frozen at the door
+  // houses/caves have no dungeon map: keep the overworld view frozen at the door.
+  // When the live "last outdoor" spot is unknown (fresh save-load, or the view was
+  // rebuilt on refocus) recover the doorway from the engine's exit table so the map
+  // still shows instead of getting stuck on the cinema card (#9).
   bool in_house = ui_mode == MODE_GAME && indoors && (dungeon_info & 0xFF) == 0xFF;
-  if (in_house && !has_last_outdoor) ui_mode = MODE_CINEMA;
+  int exit_pos[3];
+  bool have_exit = in_house && !has_last_outdoor && SS_GetIndoorExit(exit_pos);
+  if (in_house && !has_last_outdoor && !have_exit) ui_mode = MODE_CINEMA;
   if (ui_mode != MODE_GAME) {
     draw_cinema();
     SDL_RenderPresent(ss_r);
@@ -1174,7 +1180,11 @@ void SecondScreenSDL_Update(void) {
     has_last_outdoor = true;
   } else if (in_house) {
     dungeon_mode = false;
-    link_x = last_out_x; link_y = last_out_y; area = last_out_area;
+    if (has_last_outdoor) {
+      link_x = last_out_x; link_y = last_out_y; area = last_out_area;
+    } else {
+      link_x = exit_pos[0]; link_y = exit_pos[1]; area = exit_pos[2];
+    }
   }
 
   draw_tiled(dungeon_mode ? tex_bg_stone : tex_bg_menu,

--- a/app/jni/src/src/second_screen.c
+++ b/app/jni/src/src/second_screen.c
@@ -74,6 +74,29 @@ void SS_ReadDungFlags(uint8 *out, int n) {
   memcpy(out, g_ram + 0xF000, n);
 }
 
+// Where the current indoor room (dungeon_room_index) comes out onto the
+// overworld, from the engine's static exit table (the same data
+// LoadOverworldFromDungeon walks). Fills out[0..2] with the exit's
+// {link x, link y, overworld screen index} and returns true when the room has
+// an entry; false for interior rooms with no direct exit, or before the assets
+// are loaded. This needs no live state, so the doorway marker is available even
+// right after a save-load or when the view is rebuilt on refocus (issue #9).
+bool SS_GetIndoorExit(int *out) {
+  if (!g_asset_ptrs[130] || !g_asset_ptrs[131] || !g_asset_ptrs[135] || !g_asset_ptrs[136])
+    return false;
+  int room = dungeon_room_index;
+  int n = (int)(kExitDataRooms_SIZE / sizeof(uint16));
+  for (int k = 0; k < n; k++) {
+    if (kExitDataRooms[k] == room) {
+      out[0] = kExitData_XCoord[k];
+      out[1] = kExitData_YCoord[k];
+      out[2] = kExitData_ScreenIndex[k];
+      return true;
+    }
+  }
+  return false;
+}
+
 // ============ runtime asset generation ============
 
 // decoded HUD 2bpp sheets 0x6a,0x6b,0x69 -> 384 tiles of 64 pixel values (0..3),

--- a/app/src/main/java/com/dishii/zelda3/GameState.java
+++ b/app/src/main/java/com/dishii/zelda3/GameState.java
@@ -19,6 +19,10 @@ public class GameState {
     public static native int getEquippedSlotX();
     /** Low byte: palace index 0..13 (0xFF in houses/caves); high byte: current floor as int8 (0=1F, -1=B1). */
     public static native int getDungeon();
+    /** Where the current indoor room exits to on the overworld, from the engine's exit table.
+     *  Fills out[0..2] = {link x, link y, overworld screen index}; false if the room has no
+     *  exit entry or assets aren't loaded. Needs no live state (works after a save-load/refocus). */
+    public static native boolean getIndoorExit(int[] out);
     /** Fills out (up to 0x500 bytes) with save_dung_info: uint16/room, low nibble = visited quadrants. */
     public static native void readDungFlags(byte[] out);
     /** Request equipping the item in grid slot 1..20; applied on the game thread. */

--- a/app/src/main/java/com/dishii/zelda3/MinimapView.java
+++ b/app/src/main/java/com/dishii/zelda3/MinimapView.java
@@ -161,6 +161,7 @@ public class MinimapView extends View {
     private int uiMode = MODE_GAME;
     private int lastOutX, lastOutY, lastOutArea;
     private boolean hasLastOutdoor = false;
+    private final int[] exitBuf = new int[3];   // exit-table {x, y, screen} for the current room
 
     private static final String[] ITEM_NAMES = {
         "bow", "boomerang", "hookshot", "bombs", "mushroom",
@@ -364,7 +365,19 @@ public class MinimapView extends View {
         // houses and caves have no dungeon map (same test the game uses for X); keep the
         // overworld map with the marker frozen at the doorway Link came in through
         boolean inHouse = uiMode == MODE_GAME && indoors && (dungeonInfo & 0xFF) == 0xFF;
-        if (inHouse && !hasLastOutdoor)
+        // When the live "last outdoor" spot is unknown (fresh save-load, or the view
+        // was rebuilt when the app regained focus) recover the doorway from the
+        // engine's exit table so the overworld map still shows, HUD/tabs and all,
+        // instead of getting stuck on the cinema card (#9).
+        boolean haveExit = false;
+        if (inHouse && !hasLastOutdoor && !nativeBroken) {
+            try {
+                haveExit = GameState.getIndoorExit(exitBuf);
+            } catch (UnsatisfiedLinkError e) {
+                nativeBroken = true;
+            }
+        }
+        if (inHouse && !hasLastOutdoor && !haveExit)
             uiMode = MODE_CINEMA;
         if (uiMode != MODE_GAME || !artReady) {
             drawCinemaScreen(canvas, w, h);
@@ -376,7 +389,11 @@ public class MinimapView extends View {
             hasLastOutdoor = true;
         } else if (inHouse) {
             dungeonMode = false;
-            linkX = lastOutX; linkY = lastOutY; area = lastOutArea;
+            if (hasLastOutdoor) {
+                linkX = lastOutX; linkY = lastOutY; area = lastOutArea;
+            } else {
+                linkX = exitBuf[0]; linkY = exitBuf[1]; area = exitBuf[2];
+            }
         }
 
         canvas.drawRect(0, 0, w, h, dungeonMode ? stonePaint : menuPaint);


### PR DESCRIPTION
## Problem

Fixes #9. The bottom screen got stuck on the Triforce/cinema card — with the tab bar and sidebar gone, so HUD/Gear/Items/Settings were all unusable — whenever:

- a save loaded while Link was in a house/cave with no dungeon map (e.g. Link's house, the passage under Hyrule Castle), or
- the app regained focus while Link was in such a room.

It only recovered once Link stepped out to the overworld. Reported on the AYN Thor and reproduced on the AYANEO Pocket DS.

## Root cause

For a dungeonless indoor room (`dungeon == 0xFF`) the map falls back to Link's last outdoor position, but forces `MODE_CINEMA` when the `hasLastOutdoor` flag is false — and that early-return also skips drawing the tab bar/sidebar. `hasLastOutdoor` is live instance state: backgrounding rebuilds the whole Presentation + view (so it's wiped), and save-load never sets it. With no doorway to anchor the overworld view, the screen dropped to the cinema card.

## Fix

Add `SS_GetIndoorExit` to the shared second-screen core: it reads the engine's own exit table (`kExitDataRooms` / `kExitData_XCoord` / `_YCoord` / `_ScreenIndex`), keyed on `dungeon_room_index`, and returns where the current room comes out on the overworld — the same static data `LoadOverworldFromDungeon` uses. When the live position is unknown, both front-ends recover the doorway marker from it instead of dropping to the cinema card, so the map, HUD and tabs stay usable with **no persisted state needed**. Rooms with no exit-table entry still fall back to the cinema card as before.

- `second_screen.c` — new `SS_GetIndoorExit` core getter (bounded table search)
- `second_screen_jni.c` + `GameState.java` — `getIndoorExit` JNI bridge
- `MinimapView.java` — exit-table fallback before forcing `MODE_CINEMA`
- `second_screen_sdl.c` — same fix mirrored into the Linux port (had the identical bug)

## Testing

- Linux `make zelda3` target **builds and links clean** (gcc 14, `-std=gnu17`) with the core + SDL changes.
- ⚠️ Not yet device-tested on Android (built in an environment without the NDK). Suggested on-device checks:
  1. Save inside Link's house / the Hyrule Castle passage, reload → bottom screen shows the overworld map at the door and all tabs work.
  2. In such a room, background the app and return → same.
  3. Real dungeons and outdoor areas unaffected.
  4. Interior rooms with no exit-table entry still show the cinema card (acceptable).
