### PR TITLE
Add a SWAP SCREENS option to run the game on the bottom panel

### DIFF
--- a/app/jni/src/src/config.c
+++ b/app/jni/src/src/config.c
@@ -476,7 +476,8 @@ static bool HandleIniConfig(int section, const char *key, char *value) {
     } else if (StringEqualsNoCase(key, "Language")) {
       g_config.language = value;
       return true;
-    } else if (StringEqualsNoCase(key, "SecondScreenXItemRing")) {
+    } else if (StringEqualsNoCase(key, "SecondScreenXItemRing") ||
+               StringEqualsNoCase(key, "SecondScreenSwap")) {
       return true;  // read by the second-screen UI only, the engine ignores it
     }
   } else if (section == 4) {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -87,6 +87,14 @@
             </intent-filter>
         </activity>
 
+        <activity android:name="CompanionActivity"
+            android:label="@string/app_name"
+            android:exported="false"
+            android:screenOrientation="sensorLandscape"
+            android:configChanges="layoutDirection|locale|orientation|uiMode|screenLayout|screenSize|smallestScreenSize|keyboard|keyboardHidden|navigation"
+            >
+        </activity>
+
         <activity android:name="MainActivity"
             android:label="@string/app_name"
             android:alwaysRetainTaskState="true"

--- a/app/src/main/java/com/dishii/zelda3/CompanionActivity.java
+++ b/app/src/main/java/com/dishii/zelda3/CompanionActivity.java
@@ -1,0 +1,81 @@
+package com.dishii.zelda3;
+
+import android.app.Activity;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.WindowManager;
+
+import java.io.File;
+import java.io.FileOutputStream;
+
+/**
+ * Hosts the MinimapView on the device's MAIN display when the game runs on the
+ * secondary one (SecondScreenSwap = 1 in zelda3.ini). A Presentation can't be
+ * used for this: the framework refuses to attach presentation windows to the
+ * default display (InvalidDisplayException), so the swapped layout needs a real
+ * activity. The window is non-focusable for the same reason the Presentation
+ * is: gamepad input must stay with the game window even while this screen is
+ * being touched.
+ */
+public class CompanionActivity extends Activity {
+
+    private static final String TAG = "Zelda3SecondScreen";
+
+    // The game activity starts/finishes us and the DUMP debug broadcast needs
+    // the live view; both run in this process, so a static instance is enough.
+    static volatile CompanionActivity instance;
+
+    private MinimapView minimap;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        // Unlike the bottom-screen Presentation, this activity is focusable: it
+        // owns the default display, and leaving that display with no focusable
+        // window makes any input routed there ANR ("no focused window"). The
+        // game runs on a separate display and keeps its own per-display focus,
+        // so touching this screen doesn't steal the gamepad from the game.
+        getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        getWindow().getDecorView().setBackgroundColor(Color.BLACK);
+        getWindow().getDecorView().setSystemUiVisibility(
+                android.view.View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+                | android.view.View.SYSTEM_UI_FLAG_FULLSCREEN
+                | android.view.View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                | android.view.View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                | android.view.View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                | android.view.View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION);
+        minimap = new MinimapView(this);
+        setContentView(minimap);
+        instance = this;
+        Log.i(TAG, "Companion activity up on display "
+                + getWindowManager().getDefaultDisplay().getDisplayId());
+    }
+
+    @Override
+    protected void onDestroy() {
+        if (instance == this) {
+            instance = null;
+        }
+        super.onDestroy();
+    }
+
+    /** Debug: render the current view into a PNG (triggered via adb broadcast). */
+    void dumpToFile(File file) {
+        if (minimap == null || minimap.getWidth() == 0) return;
+        try {
+            Bitmap b = Bitmap.createBitmap(minimap.getWidth(), minimap.getHeight(),
+                    Bitmap.Config.ARGB_8888);
+            minimap.draw(new Canvas(b));
+            try (FileOutputStream fos = new FileOutputStream(file)) {
+                b.compress(Bitmap.CompressFormat.PNG, 100, fos);
+            }
+            b.recycle();
+            Log.i(TAG, "dumped " + file);
+        } catch (Exception e) {
+            Log.e(TAG, "dump failed", e);
+        }
+    }
+}

--- a/app/src/main/java/com/dishii/zelda3/MainActivity.java
+++ b/app/src/main/java/com/dishii/zelda3/MainActivity.java
@@ -57,6 +57,8 @@ public class MainActivity extends SDLActivity {
         public void onReceive(Context context, Intent intent) {
             if (secondScreen != null) {
                 secondScreen.dumpToFile(new File(getExternalFilesDir(null), "second_screen.png"));
+            } else if (CompanionActivity.instance != null) {
+                CompanionActivity.instance.dumpToFile(new File(getExternalFilesDir(null), "second_screen.png"));
             }
             byte[] b = new byte[256];
             try {
@@ -129,15 +131,25 @@ public class MainActivity extends SDLActivity {
         setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
     }
 
-    // Show the companion Presentation on the first non-default display
-    // (the Ayn Thor's bottom screen, or an emulator's simulated display).
+    // Show the companion Presentation on the first display the game itself is
+    // not running on. When the activity lives on the default display (normal
+    // case) that's the Thor's bottom screen; when the game is launched onto a
+    // secondary display, the companion falls back to the main panel instead.
     private void showSecondScreenIfPresent() {
         if (secondScreen != null || secondScreenHidden) {
             return;
         }
+        int gameDisplayId = getWindowManager().getDefaultDisplay().getDisplayId();
         for (Display display : displayManager.getDisplays()) {
-            if (display.getDisplayId() == Display.DEFAULT_DISPLAY) {
+            if (display.getDisplayId() == gameDisplayId) {
                 continue;
+            }
+            // The framework refuses Presentation windows on the default display,
+            // so when the game itself runs on a secondary display (SecondScreenSwap)
+            // the companion UI is hosted by a plain activity there instead.
+            if (display.getDisplayId() == Display.DEFAULT_DISPLAY) {
+                startCompanionActivity(display.getDisplayId());
+                return;
             }
             try {
                 secondScreen = new SecondScreenPresentation(this, display);
@@ -177,6 +189,26 @@ public class MainActivity extends SDLActivity {
             secondScreen.dismiss();
             secondScreen = null;
         }
+        CompanionActivity companion = CompanionActivity.instance;
+        if (companion != null) {
+            companion.finish();
+        }
+    }
+
+    // Companion UI on the main display for the swapped-screens layout. Launched
+    // in its own task (required to target another display); the window is
+    // non-focusable so gamepad input stays with the game, mirroring the
+    // Presentation's behavior on the bottom screen.
+    private void startCompanionActivity(int displayId) {
+        if (CompanionActivity.instance != null || Build.VERSION.SDK_INT < 26) {
+            return;
+        }
+        Intent intent = new Intent(this, CompanionActivity.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        android.app.ActivityOptions options = android.app.ActivityOptions.makeBasic();
+        options.setLaunchDisplayId(displayId);
+        startActivity(intent, options.toBundle());
+        Log.i(TAG, "Launching companion activity on display " + displayId);
     }
 
     // Use onStop/onStart rather than onPause/onResume: onPause also fires for

--- a/app/src/main/java/com/dishii/zelda3/MinimapView.java
+++ b/app/src/main/java/com/dishii/zelda3/MinimapView.java
@@ -129,7 +129,7 @@ public class MinimapView extends View {
     // touch regions (recomputed during draw)
     private final RectF tabItemsR = new RectF(), tabGearR = new RectF();
     private final RectF tabSettingsR = new RectF(), remapBackR = new RectF();
-    private final RectF[] settingsRowR = new RectF[4 + FEAT_MASKS.length];
+    private final RectF[] settingsRowR = new RectF[5 + FEAT_MASKS.length];
     private final RectF[] remapRowR = new RectF[12];
     private final RectF mapAreaR = new RectF(), yRingR = new RectF(), xRingR = new RectF();
 
@@ -144,6 +144,8 @@ public class MinimapView extends View {
     private final int[] padControls = new int[12];
     private boolean hudPrefApplied = false;
     private boolean xRing = false;      // second ring with the X-assigned item (ItemSwitchLR)
+    // which screen hosts the game; toggling takes effect on the next app start
+    private boolean swapScreens, swapScreensApplied;
     private int armedRing = 0;          // 1/2 = next items-grid tap assigns Y/X
     private static final String[] PAD_CMD_NAMES = {
         "UP", "DOWN", "LEFT", "RIGHT", "SELECT", "START", "A", "B", "X", "Y", "L", "R",
@@ -196,6 +198,7 @@ public class MinimapView extends View {
         for (int i = 0; i < remapRowR.length; i++) remapRowR[i] = new RectF();
         for (int i = 0; i < settingsRowR.length; i++) settingsRowR[i] = new RectF();
         xRing = readIniBool("[General]", "SecondScreenXItemRing");
+        swapScreens = swapScreensApplied = readIniBool("[General]", "SecondScreenSwap");
         loadAssets(context);
     }
 
@@ -731,8 +734,12 @@ public class MinimapView extends View {
             else if (i == 1) { label = "WIDESCREEN"; v = ws ? "ON" : "OFF"; }
             else if (i == 2) { label = "TOP SCREEN HUD"; v = hudHidden ? "OFF" : "ON"; }
             else if (i == 3) { label = "X ITEM RING"; v = xRing ? "ON" : "OFF"; }
+            else if (i == 4) {
+                label = "SWAP SCREENS";
+                v = swapScreens != swapScreensApplied ? "RESTART" : (swapScreens ? "ON" : "OFF");
+            }
             else {
-                int f = i - 4;
+                int f = i - 5;
                 label = FEAT_LABELS[f];
                 v = (((feats & FEAT_MASKS[f]) != 0) ^ FEAT_INVERT[f]) ? "ON" : "OFF";
             }
@@ -790,8 +797,13 @@ public class MinimapView extends View {
                     GameState.setFeature(FEAT_MASKS[0], true);
                     updateIni(FEAT_SECTIONS[0], FEAT_KEYS[0], "1");
                 }
+            } else if (i == 4) {
+                // needs the game window rebuilt on the other display, which only
+                // happens at activity launch - the row shows RESTART until then
+                swapScreens = !swapScreens;
+                updateIni("[General]", "SecondScreenSwap", swapScreens ? "1" : "0");
             } else {
-                int f = i - 4;
+                int f = i - 5;
                 boolean on = (GameState.getFeatures() & FEAT_MASKS[f]) == 0;
                 GameState.setFeature(FEAT_MASKS[f], on);
                 updateIni(FEAT_SECTIONS[f], FEAT_KEYS[f], on ? "1" : "0");

--- a/app/src/main/java/com/dishii/zelda3/SetupActivity.java
+++ b/app/src/main/java/com/dishii/zelda3/SetupActivity.java
@@ -73,8 +73,57 @@ public class SetupActivity extends Activity {
     }
 
     private void launchGame() {
-        startActivity(new Intent(this, MainActivity.class));
+        Intent intent = new Intent(this, MainActivity.class);
+        int display = swapDisplayId();
+        if (display != -1 && Build.VERSION.SDK_INT >= 26) {
+            android.app.ActivityOptions options = android.app.ActivityOptions.makeBasic();
+            options.setLaunchDisplayId(display);
+            startActivity(intent, options.toBundle());
+        } else {
+            startActivity(intent);
+        }
         finish();
+    }
+
+    /**
+     * With SecondScreenSwap = 1 in zelda3.ini the game runs on the secondary
+     * display (e.g. the Thor's bottom screen) and the companion map takes the
+     * main one. Returns the display to launch the game on, or -1 for the
+     * default launch (flag off, no ini yet, or no second display attached).
+     */
+    private int swapDisplayId() {
+        File dir = getExternalFilesDir(null);
+        if (dir == null || !readIniBool(new File(dir, "zelda3.ini"), "[General]", "SecondScreenSwap")) {
+            return -1;
+        }
+        android.hardware.display.DisplayManager dm =
+                (android.hardware.display.DisplayManager) getSystemService(DISPLAY_SERVICE);
+        for (android.view.Display d : dm.getDisplays()) {
+            if (d.getDisplayId() != android.view.Display.DEFAULT_DISPLAY) {
+                return d.getDisplayId();
+            }
+        }
+        return -1;
+    }
+
+    /** Minimal `key = value` lookup inside one [section] of an ini file. */
+    private static boolean readIniBool(File ini, String section, String key) {
+        try (java.io.BufferedReader in = new java.io.BufferedReader(new java.io.FileReader(ini))) {
+            String line, cur = "";
+            while ((line = in.readLine()) != null) {
+                String t = line.trim();
+                if (t.startsWith("[")) {
+                    cur = t;
+                } else if (cur.equalsIgnoreCase(section)
+                        && t.toLowerCase().startsWith(key.toLowerCase())
+                        && t.substring(key.length()).trim().startsWith("=")) {
+                    String v = t.substring(t.indexOf('=') + 1).trim();
+                    return v.equals("1") || v.equalsIgnoreCase("true");
+                }
+            }
+        } catch (IOException ignored) {
+        }
+        return false;
     }
 
     // ---- UI (built in code to avoid pulling in layout/androidx deps) ----


### PR DESCRIPTION
Adds an opt-in **SWAP SCREENS** option so the game can run on the bottom panel and the companion map/inventory on the main screen. Requested for the Retroid Pocket Mini + dual-screen add-on (#8).

## How it works
- New `SecondScreenSwap` flag under `[General]` in `zelda3.ini`, toggled from the bottom-screen settings list. It shows **RESTART** until the app is relaunched, because the game window has to be rebuilt on the other display (`MainActivity` is `singleInstance`, so there's no live flip).
- When set, `SetupActivity` launches the game onto the secondary display (`setLaunchDisplayId`).
- The companion UI can't ride the existing `Presentation` there — the framework refuses `Presentation` windows on the default display (`InvalidDisplayException`). So a new `CompanionActivity` hosts `MinimapView` on the main display for the swapped case.
- That activity is **focusable** (unlike the Presentation): leaving the default display with no focusable window makes any input routed there ANR. The game keeps its own per-display focus, so touching the companion doesn't pull the gamepad off the game.
- The engine ignores the key (read by the UI layer only), same as `SecondScreenXItemRing`.

## Default is unchanged
The key is **not** in the shipped `zelda3.ini`, so it reads as off. Every existing and fresh install behaves exactly as before — game on the main screen, companion on the bottom — with no ini rewrite. The swap is purely opt-in.

## Testing
Verified in the Android emulator with a virtual secondary display: toggle on → relaunch → game runs and takes input on the secondary display while the full companion map/HUD/tabs render and respond to touch on the main display; toggle off restores the normal layout; no ANR.

⚠️ Not yet tested on real dual-screen hardware. The one thing an emulator can't confirm is whether the physical gamepad reaches the game when it's on the bottom panel (per-display focus should route it, but a device is needed to be sure). The default (non-swapped) path is unaffected either way.
