### PR TITLE
Add save state and autosave controls to the settings screen

### DIFF
--- a/app/jni/src/src/platform/android/second_screen_jni.c
+++ b/app/jni/src/src/platform/android/second_screen_jni.c
@@ -17,6 +17,7 @@ int SS_GetCapturedButton(void); void SS_GetGamepadControls(int *out); void SS_Se
 int SS_GetEquippedSlotX(void); void SS_AssignSlotX(int slot);
 uint32 SS_GetFeatures(void); void SS_SetFeature(unsigned mask, bool on);
 bool SS_GetIndoorExit(int *out);
+void SS_SaveLoadState(bool save); void SS_SetAutosave(bool on);
 
 #include <jni.h>
 
@@ -110,6 +111,9 @@ JNIEXPORT void JNICALL Java_com_dishii_zelda3_GameState_setHudHidden(JNIEnv *env
 JNIEXPORT jboolean JNICALL Java_com_dishii_zelda3_GameState_isHudHidden(JNIEnv *env, jclass clazz) { return SS_IsHudHidden(); }
 JNIEXPORT jint JNICALL Java_com_dishii_zelda3_GameState_getFeatures(JNIEnv *env, jclass clazz) { return (jint)SS_GetFeatures(); }
 JNIEXPORT void JNICALL Java_com_dishii_zelda3_GameState_setFeature(JNIEnv *env, jclass clazz, jint mask, jboolean on) { SS_SetFeature((unsigned)mask, on); }
+JNIEXPORT void JNICALL Java_com_dishii_zelda3_GameState_saveState(JNIEnv *env, jclass clazz) { SS_SaveLoadState(true); }
+JNIEXPORT void JNICALL Java_com_dishii_zelda3_GameState_loadState(JNIEnv *env, jclass clazz) { SS_SaveLoadState(false); }
+JNIEXPORT void JNICALL Java_com_dishii_zelda3_GameState_setAutosave(JNIEnv *env, jclass clazz, jboolean on) { SS_SetAutosave(on); }
 JNIEXPORT void JNICALL Java_com_dishii_zelda3_GameState_armButtonCapture(JNIEnv *env, jclass clazz, jboolean arm) { SS_ArmButtonCapture(arm); }
 JNIEXPORT jint JNICALL Java_com_dishii_zelda3_GameState_getCapturedButton(JNIEnv *env, jclass clazz) { return SS_GetCapturedButton(); }
 

--- a/app/jni/src/src/second_screen.c
+++ b/app/jni/src/src/second_screen.c
@@ -405,6 +405,7 @@ static volatile int g_pending_widescreen = -1;
 static volatile int g_pending_hide_hud = -1;
 static volatile int g_pending_controls_set;
 static uint8 g_pending_controls[12];
+static volatile int g_pending_saveload;  // 0 idle, 1 save, 2 load
 // kFeatures0_* bits to set/clear; ZeldaRunFrame latches the result into game ram.
 static volatile uint32 g_pending_features_on, g_pending_features_off;
 // Redraw the top HUD once the changed feature bits have reached game ram.
@@ -455,6 +456,12 @@ void SS_SetFeature(unsigned mask, bool on) {
     g_pending_features_off |= (uint32)mask;
   }
 }
+
+// Settings-screen save state. Slot 1: slot 0 belongs to the Autosave option,
+// which would overwrite it on exit.
+void SS_SaveLoadState(bool save) { g_pending_saveload = save ? 1 : 2; }
+
+void SS_SetAutosave(bool on) { g_config.autosave = on; }
 
 void SS_ArmButtonCapture(bool arm) { g_ss_capture_button = arm ? -2 : -1; }
 
@@ -525,6 +532,14 @@ void SecondScreen_RunFrameHook(void) {
     g_ss_hud_refresh = false;
     if (!g_ss_hide_hud && (main_module_index == 7 || main_module_index == 9 || main_module_index == 14))
       Hud_Rebuild();
+  }
+  int sl = g_pending_saveload;
+  if (sl) {
+    g_pending_saveload = 0;
+    // SaveLoadSlot touches the APU; the audio callback must not run meanwhile.
+    ZeldaApuLock();
+    SaveLoadSlot(sl == 1 ? kSaveLoad_Save : kSaveLoad_Load, 1);
+    ZeldaApuUnlock();
   }
   // Only during normal overworld/dungeon gameplay, not in menus or cutscenes.
   bool in_gameplay = (main_module_index == 7 || main_module_index == 9) && submodule_index == 0;

--- a/app/src/main/java/com/dishii/zelda3/GameState.java
+++ b/app/src/main/java/com/dishii/zelda3/GameState.java
@@ -38,6 +38,13 @@ public class GameState {
     public static native int getFeatures();
     /** Set or clear kFeatures0_* flag bits; applied on the game thread. */
     public static native void setFeature(int mask, boolean on);
+    /** Write a save state to saves/save1.sav; applied on the game thread.
+     *  (Slot 0 is the Autosave slot, which gets overwritten on every exit.) */
+    public static native void saveState();
+    /** Restore the save state from saves/save1.sav; applied on the game thread. */
+    public static native void loadState();
+    /** Save state to slot 0 on exit and reload it on launch (the ini Autosave option). */
+    public static native void setAutosave(boolean on);
     /** Arm (or cancel) capture of the next gamepad button press; the press is swallowed. */
     public static native void armButtonCapture(boolean arm);
     /** The captured button index, consuming it; -2 = still waiting, -1 = idle. */

--- a/app/src/main/java/com/dishii/zelda3/MinimapView.java
+++ b/app/src/main/java/com/dishii/zelda3/MinimapView.java
@@ -129,7 +129,7 @@ public class MinimapView extends View {
     // touch regions (recomputed during draw)
     private final RectF tabItemsR = new RectF(), tabGearR = new RectF(), tabMapR = new RectF();
     private final RectF tabSettingsR = new RectF(), remapBackR = new RectF();
-    private final RectF[] settingsRowR = new RectF[5 + FEAT_MASKS.length];
+    private final RectF[] settingsRowR = new RectF[8 + FEAT_MASKS.length];
     private final RectF[] remapRowR = new RectF[12];
     private final RectF mapAreaR = new RectF(), yRingR = new RectF(), xRingR = new RectF();
 
@@ -146,6 +146,11 @@ public class MinimapView extends View {
     private boolean xRing = false;      // second ring with the X-assigned item (ItemSwitchLR)
     // which screen hosts the game; toggling takes effect on the next app start
     private boolean swapScreens, swapScreensApplied;
+    private boolean autosave;
+    // transient feedback on an action row ("SAVED"/"LOADED"/"EMPTY")
+    private int settingsFlashRow = -1;
+    private long settingsFlashUntil;
+    private String settingsFlash = "";
     private int armedRing = 0;          // 1/2 = next items-grid tap assigns Y/X
     private static final String[] PAD_CMD_NAMES = {
         "UP", "DOWN", "LEFT", "RIGHT", "SELECT", "START", "A", "B", "X", "Y", "L", "R",
@@ -199,6 +204,7 @@ public class MinimapView extends View {
         for (int i = 0; i < settingsRowR.length; i++) settingsRowR[i] = new RectF();
         xRing = readIniBool("[General]", "SecondScreenXItemRing");
         swapScreens = swapScreensApplied = readIniBool("[General]", "SecondScreenSwap");
+        autosave = readIniBool("[General]", "Autosave");
         loadAssets(context);
     }
 
@@ -731,15 +737,18 @@ public class MinimapView extends View {
             float ty = row.centerY() - 12 * u;
             String label, v;
             if (i == 0) { label = "REMAP BUTTONS"; v = null; }
-            else if (i == 1) { label = "WIDESCREEN"; v = ws ? "ON" : "OFF"; }
-            else if (i == 2) { label = "TOP SCREEN HUD"; v = hudHidden ? "OFF" : "ON"; }
-            else if (i == 3) { label = "X ITEM RING"; v = xRing ? "ON" : "OFF"; }
-            else if (i == 4) {
+            else if (i == 1) { label = "SAVE STATE"; v = rowFlash(i, ""); }
+            else if (i == 2) { label = "LOAD STATE"; v = rowFlash(i, stateFile().exists() ? "" : "EMPTY"); }
+            else if (i == 3) { label = "AUTOSAVE"; v = autosave ? "ON" : "OFF"; }
+            else if (i == 4) { label = "WIDESCREEN"; v = ws ? "ON" : "OFF"; }
+            else if (i == 5) { label = "TOP SCREEN HUD"; v = hudHidden ? "OFF" : "ON"; }
+            else if (i == 6) { label = "X ITEM RING"; v = xRing ? "ON" : "OFF"; }
+            else if (i == 7) {
                 label = "SWAP SCREENS";
                 v = swapScreens != swapScreensApplied ? "RESTART" : (swapScreens ? "ON" : "OFF");
             }
             else {
-                int f = i - 5;
+                int f = i - 8;
                 label = FEAT_LABELS[f];
                 v = (((feats & FEAT_MASKS[f]) != 0) ^ FEAT_INVERT[f]) ? "ON" : "OFF";
             }
@@ -779,15 +788,30 @@ public class MinimapView extends View {
                 GameState.getGamepadControls(padControls);
                 remapMode = true;
             } else if (i == 1) {
+                stateFile().getParentFile().mkdirs();
+                GameState.saveState();
+                rowFlashSet(i, "SAVED");
+            } else if (i == 2) {
+                if (stateFile().exists()) {
+                    GameState.loadState();
+                    rowFlashSet(i, "LOADED");
+                } else {
+                    rowFlashSet(i, "EMPTY");
+                }
+            } else if (i == 3) {
+                autosave = !autosave;
+                GameState.setAutosave(autosave);
+                updateIni("[General]", "Autosave", autosave ? "1" : "0");
+            } else if (i == 4) {
                 boolean on = !GameState.isWidescreen();
                 GameState.setWidescreen(on);
                 updateIni("[General]", "ExtendedAspectRatio", on ? "16:9" : "4:3");
-            } else if (i == 2) {
+            } else if (i == 5) {
                 boolean hide = !GameState.isHudHidden();
                 GameState.setHudHidden(hide);
                 getContext().getSharedPreferences("secondscreen", 0)
                         .edit().putBoolean("hideTopHud", hide).apply();
-            } else if (i == 3) {
+            } else if (i == 6) {
                 xRing = !xRing;
                 armedRing = 0;
                 updateIni("[General]", "SecondScreenXItemRing", xRing ? "1" : "0");
@@ -797,13 +821,13 @@ public class MinimapView extends View {
                     GameState.setFeature(FEAT_MASKS[0], true);
                     updateIni(FEAT_SECTIONS[0], FEAT_KEYS[0], "1");
                 }
-            } else if (i == 4) {
+            } else if (i == 7) {
                 // needs the game window rebuilt on the other display, which only
                 // happens at activity launch - the row shows RESTART until then
                 swapScreens = !swapScreens;
                 updateIni("[General]", "SecondScreenSwap", swapScreens ? "1" : "0");
             } else {
-                int f = i - 5;
+                int f = i - 8;
                 boolean on = (GameState.getFeatures() & FEAT_MASKS[f]) == 0;
                 GameState.setFeature(FEAT_MASKS[f], on);
                 updateIni(FEAT_SECTIONS[f], FEAT_KEYS[f], on ? "1" : "0");
@@ -857,6 +881,22 @@ public class MinimapView extends View {
                        ? GameState.PAD_BUTTON_LABEL[padControls[i]] : "----");
             drawText(c, v, row.right - 14 * u - textWidth(v, 2.2f * u), ty, 2.2f * u);
         }
+    }
+
+    // The settings-screen save state; slot 0 is reserved for the Autosave option.
+    private java.io.File stateFile() {
+        return new java.io.File(getContext().getExternalFilesDir(null), "saves/save1.sav");
+    }
+
+    private void rowFlashSet(int row, String text) {
+        settingsFlashRow = row;
+        settingsFlash = text;
+        settingsFlashUntil = System.nanoTime() + 1_200_000_000L;
+    }
+
+    private String rowFlash(int row, String dflt) {
+        return settingsFlashRow == row && System.nanoTime() < settingsFlashUntil
+                ? settingsFlash : dflt;
     }
 
     // Rewrite one `key = value` line inside a section of the user's zelda3.ini.


### PR DESCRIPTION
Adds three rows to the bottom-screen settings list, right below REMAP BUTTONS:

- SAVE STATE / LOAD STATE: instant save state from the touch screen. Uses slot 1 (saves/save1.sav) so the Autosave option, which owns slot 0, can never overwrite a manual save on exit. The row flashes SAVED/LOADED for feedback, and LOAD STATE shows EMPTY until a state exists.
- AUTOSAVE: toggles the ini Autosave option (save state on quit, resume on launch). Applied live so enabling it mid-session still saves on that exit.

The actual save/load runs on the game thread through the existing pending-request pattern in second_screen.c, holding the APU lock like the desktop F-key path does. New JNI entry points: saveState(), loadState(), setAutosave().